### PR TITLE
add terms based scoring scripts

### DIFF
--- a/example/termscoring.sh
+++ b/example/termscoring.sh
@@ -1,0 +1,262 @@
+#!/bin/sh
+
+# Init an index that includes wordcount for the field that we will be searching on:
+
+curl -XPUT "http://localhost:9200/termscore" -d'
+{
+   "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0
+   },
+   "mappings": {
+      "doc": {
+         "properties": {
+            "text": {
+               "type": "multi_field",
+               "fields": {
+                  "text": {
+                     "type": "string"
+                  },
+                  "word_count": {
+                     "type": "token_count",
+                     "store": "yes",
+                     "analyzer": "standard"
+                  }
+               }
+            }
+         }
+      }
+   }
+}'
+
+curl -XPOST "http://localhost:9200/termscore/doc" -d'
+{
+   "text": "John Smith is the main villain in the Matrix."
+}'
+
+curl -XPOST "http://localhost:9200/termscore/doc" -d'
+{
+   "text": "John \"Hannibal\" Smith is the leader of the A-team."
+}'
+
+curl -XPOST "http://localhost:9200/termscore/_refresh" 
+
+# search for people that are named John Smith:
+
+curl -XPOST "http://localhost:9200/termscore/doc/_search?pretty" -d'
+{
+   "query": {
+      "function_score": {
+         "query": {
+            "bool": {
+               "must": [
+                  {
+                     "match": {
+                        "text": {
+                           "query": "john smith",
+                           "operator": "and"
+                        }
+                     }
+                  }
+               ]
+            }
+         },
+         "functions": [
+            {
+               "script_score": {
+                  "params": {
+                     "field": "text",
+                     "terms": [
+                        "john",
+                        "smith"
+                     ]
+                  },
+                  "script": "phrase_script_score",
+                  "lang": "native"
+               }
+            }
+         ],
+         "boost_mode": "replace"
+      }
+   }
+}'
+
+curl -XPOST "http://localhost:9200/termscore/doc" -d'
+{
+   "text": "I am Sam. I am Sam. Sam I am. That Sam-I-am.    That Sam-I-am! I do not like that Sam-I-am. Do you like green eggs and ham? I do not like them, Sam-I-am.I do not like green eggs and ham."
+}'
+
+curl -XPOST "http://localhost:9200/termscore/doc" -d'
+{
+   "text": "Would you like them Here or there? I would not like them here or there. I would not like them anywhere. I do not like green eggs and ham. I do not like them, Sam-I-am."
+}'
+
+curl -XPOST "http://localhost:9200/termscore/doc" -d'
+{
+   "text": "Would you like them in a house? Would you like them with a mouse? I do not like them in a house. I do not like them with a mouse. I do not like them here or there. I do not like them anywhere. I do not like green eggs and ham. I do not like them, Sam-I-am."
+}'
+
+curl -XPOST "http://localhost:9200/termscore/_refresh" 
+
+# Search for "I am Sam" with cosine similarity:
+
+curl -XPOST "http://localhost:9200/termscore/doc/_search?pretty" -d'
+{
+   "script_fields": {
+      "i-tf": {
+         "script": "_index[\"text\"][\"i\"].tf()"
+      },
+      "am-tf": {
+         "script": "_index[\"text\"][\"am\"].tf()"
+      },
+      "sam-tf": {
+         "script": "_index[\"text\"][\"sam\"].tf()"
+      }
+   },
+   "query": {
+      "function_score": {
+         "query": {
+            "bool": {
+               "must": [
+                  {
+                     "match": {
+                        "text": {
+                           "query": "sam i am",
+                           "operator": "and"
+                        }
+                     }
+                  }
+               ]
+            }
+         },
+         "functions": [
+            {
+               "script_score": {
+                  "params": {
+                     "field": "text",
+                     "terms": [
+                        "sam",
+                        "i",
+                        "am"
+                     ],
+                     "weights": [
+                        1.0,
+                        1.0,
+                        1.0
+                     ]
+                  },
+                  "script": "cosine_sim_script_score",
+                  "lang": "native"
+               }
+            }
+         ],
+         "boost_mode": "replace"
+      }
+   }
+}'
+
+# Search for "I am Sam" with naive tf-ifd score:
+
+curl -XPOST "http://localhost:9200/termscore/doc/_search?pretty" -d'
+{
+   "script_fields": {
+      "i-tf": {
+         "script": "_index[\"text\"][\"i\"].tf()"
+      },
+      "am-tf": {
+         "script": "_index[\"text\"][\"am\"].tf()"
+      },
+      "sam-tf": {
+         "script": "_index[\"text\"][\"sam\"].tf()"
+      }
+   },
+   "query": {
+      "function_score": {
+         "query": {
+            "bool": {
+               "must": [
+                  {
+                     "match": {
+                        "text": {
+                           "query": "sam i am",
+                           "operator": "and"
+                        }
+                     }
+                  }
+               ]
+            }
+         },
+         "functions": [
+            {
+               "script_score": {
+                  "params": {
+                     "field": "text",
+                     "terms": [
+                        "sam",
+                        "i",
+                        "am"
+                     ]
+                  },
+                  "script": "tfidf_script_score",
+                  "lang": "native"
+               }
+            }
+         ],
+         "boost_mode": "replace"
+      }
+   }
+}'
+
+# Search for "I am Sam" with language model scoring:
+
+curl -XPOST "http://localhost:9200/termscore/doc/_search?pretty" -d'
+{
+   "script_fields": {
+      "i-tf": {
+         "script": "_index[\"text\"][\"i\"].tf()"
+      },
+      "am-tf": {
+         "script": "_index[\"text\"][\"am\"].tf()"
+      },
+      "sam-tf": {
+         "script": "_index[\"text\"][\"sam\"].tf()"
+      }
+   },
+   "query": {
+      "function_score": {
+         "query": {
+            "bool": {
+               "must": [
+                  {
+                     "match": {
+                        "text": {
+                           "query": "sam i am",
+                           "operator": "and"
+                        }
+                     }
+                  }
+               ]
+            }
+         },
+         "functions": [
+            {
+               "script_score": {
+                  "params": {
+                     "field": "text",
+                     "terms": [
+                        "sam",
+                        "i",
+                        "am"
+                     ],
+                     "lambda": 0.5,
+                     "word_count_field": "text.word_count"
+                  },
+                  "script": "language_model_script_score",
+                  "lang": "native"
+               }
+            }
+         ],
+         "boost_mode": "replace"
+      }
+   }
+}'

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <!-- The Elasticsearch version that the project will be built with -->
     <!-- ============================================================= -->
     <properties>
-        <elasticsearch.version>0.90.8</elasticsearch.version>
+        <elasticsearch.version>0.90.10</elasticsearch.version>
         <lucene.version>4.6.0</lucene.version>
     </properties>
 

--- a/src/main/java/org/elasticsearch/examples/nativescript/plugin/NativeScriptExamplesPlugin.java
+++ b/src/main/java/org/elasticsearch/examples/nativescript/plugin/NativeScriptExamplesPlugin.java
@@ -1,7 +1,11 @@
 package org.elasticsearch.examples.nativescript.plugin;
 
 import org.elasticsearch.examples.nativescript.script.IsPrimeSearchScript;
+import org.elasticsearch.examples.nativescript.script.LanguageModelScoreScript;
 import org.elasticsearch.examples.nativescript.script.LookupScript;
+import org.elasticsearch.examples.nativescript.script.CosineSimilarityScoreScript;
+import org.elasticsearch.examples.nativescript.script.PhraseScoreScript;
+import org.elasticsearch.examples.nativescript.script.TFIDFScoreScript;
 import org.elasticsearch.examples.nativescript.script.PopularityScoreScriptFactory;
 import org.elasticsearch.examples.nativescript.script.RandomSortScriptFactory;
 import org.elasticsearch.plugins.AbstractPlugin;
@@ -42,5 +46,9 @@ public class NativeScriptExamplesPlugin extends AbstractPlugin {
         module.registerScript("lookup", LookupScript.Factory.class);
         module.registerScript("random", RandomSortScriptFactory.class);
         module.registerScript("popularity", PopularityScoreScriptFactory.class);
+        module.registerScript(TFIDFScoreScript.SCRIPT_NAME, TFIDFScoreScript.Factory.class);
+        module.registerScript(CosineSimilarityScoreScript.SCRIPT_NAME, CosineSimilarityScoreScript.Factory.class);
+        module.registerScript(PhraseScoreScript.SCRIPT_NAME, PhraseScoreScript.Factory.class);
+        module.registerScript(LanguageModelScoreScript.SCRIPT_NAME, LanguageModelScoreScript.Factory.class);
     }
 }

--- a/src/main/java/org/elasticsearch/examples/nativescript/script/CosineSimilarityScoreScript.java
+++ b/src/main/java/org/elasticsearch/examples/nativescript/script/CosineSimilarityScoreScript.java
@@ -1,0 +1,102 @@
+package org.elasticsearch.examples.nativescript.script;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.script.AbstractSearchScript;
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.NativeScriptFactory;
+import org.elasticsearch.search.lookup.IndexField;
+import org.elasticsearch.search.lookup.IndexFieldTerm;
+
+/**
+ * Script that scores documents with cosine similarity, see Manning et al.,
+ * "Information Retrieval", Chapter 6, Eq. 6.12 (link:
+ * http://nlp.stanford.edu/IR-book/). This implementation only scores a list of
+ * terms on one field.
+ */
+public class CosineSimilarityScoreScript extends AbstractSearchScript {
+
+    // the field containing the terms that should be scored, must be initialized
+    // in constructor from parameters.
+    String field = null;
+    // terms that are used for scoring, must be unique
+    ArrayList<String> terms = null;
+    // weights, in case we want to put emphasis on a specific term. In the most
+    // simple case, 1.0 for every term.
+    ArrayList<Double> weights = null;
+
+    final static public String SCRIPT_NAME = "cosine_sim_script_score";
+
+    /**
+     * Factory that is registered in
+     * {@link org.elasticsearch.examples.nativescript.plugin.NativeScriptExamplesPlugin#onModule(org.elasticsearch.script.ScriptModule)}
+     * method when the plugin is loaded.
+     */
+    public static class Factory implements NativeScriptFactory {
+
+        /**
+         * This method is called for every search on every shard.
+         * 
+         * @param params
+         *            list of script parameters passed with the query
+         * @return new native script
+         */
+        @Override
+        public ExecutableScript newScript(@Nullable Map<String, Object> params) {
+            return new CosineSimilarityScoreScript(params);
+        }
+    }
+
+    /**
+     * @param params
+     *            terms that a scored are placed in this parameter. Initialize
+     *            them here.
+     */
+    private CosineSimilarityScoreScript(Map<String, Object> params) {
+        params.entrySet();
+        // get the terms
+        terms = (ArrayList<String>) params.get("terms");
+        weights = (ArrayList<Double>) params.get("weights");
+        // get the field
+        field = (String) params.get("field");
+        if (field == null || terms == null || weights == null) {
+            throw new ElasticSearchException("cannot initialize " + SCRIPT_NAME + ": field, terms or weights parameter missing!");
+        }
+        if (weights.size() != terms.size()) {
+            throw new ElasticSearchException("cannot initialize " + SCRIPT_NAME + ": terms and weights array must have same length!");
+        }
+    }
+
+    @Override
+    public Object run() {
+        try {
+            float score = 0;
+            // first, get the ShardTerms object for the field.
+            IndexField indexField = this.indexLookup().get(field);
+            double queryWeightSum = 0.0f;
+            double docWeightSum = 0.0f;
+            for (int i = 0; i < terms.size(); i++) {
+                // Now, get the ShardTerm object that can be used to access all
+                // the term statistics
+                IndexFieldTerm indexTermField = indexField.get(terms.get(i));
+                // compute the most naive tfidf and add to current score
+                int df = (int) indexTermField.df();
+                int tf = indexTermField.tf();
+                if (df != 0 && tf != 0) {
+                    double termscore = (double) tf * weights.get(i);
+                    score += termscore;
+                    docWeightSum += Math.pow(tf, 2.0);
+                }
+                queryWeightSum += Math.pow(weights.get(i), 2.0);
+            }
+            return score / (Math.sqrt(docWeightSum) * Math.sqrt(queryWeightSum));
+        } catch (IOException ex) {
+            throw new ElasticSearchException("Could not compute cosine similarity: ", ex);
+        }
+    }
+
+}

--- a/src/main/java/org/elasticsearch/examples/nativescript/script/LanguageModelScoreScript.java
+++ b/src/main/java/org/elasticsearch/examples/nativescript/script/LanguageModelScoreScript.java
@@ -1,0 +1,131 @@
+package org.elasticsearch.examples.nativescript.script;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.script.AbstractSearchScript;
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.NativeScriptFactory;
+import org.elasticsearch.search.lookup.IndexField;
+import org.elasticsearch.search.lookup.IndexFieldTerm;
+
+/**
+ * Script that scores documents with a language model similarity with linear
+ * interpolation, see Manning et al., "Information Retrieval", Chapter 12,
+ * Equation 12.12 (link: http://nlp.stanford.edu/IR-book/) This implementation
+ * only scores a list of terms on one field.
+ */
+public class LanguageModelScoreScript extends AbstractSearchScript {
+
+    // the field containing the terms that should be scored, must be initialized
+    // in constructor from parameters.
+    String field;
+    // name of the field that holds the word count of a field, see
+    // http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-core-types.html)
+    String docLengthField;
+    // terms that are used for scoring
+    ArrayList<String> terms;
+    // lambda parameter
+    float lambda;
+
+    final static public String SCRIPT_NAME = "language_model_script_score";
+
+    /**
+     * Factory that is registered in
+     * {@link org.elasticsearch.examples.nativescript.plugin.NativeScriptExamplesPlugin#onModule(org.elasticsearch.script.ScriptModule)}
+     * method when the plugin is loaded.
+     */
+    public static class Factory implements NativeScriptFactory {
+
+        /**
+         * This method is called for every search on every shard.
+         * 
+         * @param params
+         *            list of script parameters passed with the query
+         * @return new native script
+         */
+        @Override
+        public ExecutableScript newScript(@Nullable Map<String, Object> params) {
+            return new LanguageModelScoreScript(params);
+        }
+    }
+
+    /**
+     * @param params
+     *            terms that a scored are placed in this parameter. Initialize
+     *            them here.
+     */
+    private LanguageModelScoreScript(Map<String, Object> params) {
+        params.entrySet();
+        // get the terms
+        terms = (ArrayList<String>) params.get("terms");
+        // get the field
+        field = (String) params.get("field");
+        // get the field holding the document length
+        docLengthField = (String) params.get("word_count_field");
+        // get lambda
+        lambda = ((Double) params.get("lambda")).floatValue();
+        if (field == null || terms == null || docLengthField == null) {
+            throw new ElasticSearchException("cannot initialize " + SCRIPT_NAME + ": field, terms or length field parameter missing!");
+        }
+    }
+
+    @Override
+    public Object run() {
+        try {
+            double score = 0.0;
+            // first, get the ShardTerms object for the field.
+            IndexField indexField = indexLookup().get(field);
+            long T = indexField.sumttf();
+            /*
+             * document length cannot be obtained by the shardTerms, we use the
+             * word_count field instead (link:
+             * http://www.elasticsearch.org/guide
+             * /en/elasticsearch/reference/current/mapping-core-types.html)
+             */
+            ScriptDocValues docValues = (ScriptDocValues) doc().get(docLengthField);
+            if (docValues == null || !docValues.isEmpty()) {
+                long L_d = ((ScriptDocValues.Longs) docValues).getValue();
+                for (int i = 0; i < terms.size(); i++) {
+                    // Now, get the ShardTerm object that can be used to access
+                    // all
+                    // the term statistics
+                    IndexFieldTerm indexFieldTerm = indexField.get(terms.get(i));
+
+                    /*
+                     * compute M_c as ttf/T, see Manning et al.,
+                     * "Information Retrieval", Chapter 12, Equation just before
+                     * Equation 12.10 (link: http://nlp.stanford.edu/IR-book/)
+                     */
+                    long cf_t = indexFieldTerm.ttf();
+                    double M_c = (double) cf_t / (double) T;
+                    /*
+                     * Compute M_d, see Manning et al., "Information Retrieval",
+                     * Chapter 12, Equation just before Equation 12.9 (link:
+                     * http://nlp.stanford.edu/IR-book/)
+                     */
+                    double M_d = (double) indexFieldTerm.tf() / (double) L_d;
+                    /*
+                     * compute score contribution for this term, but sum the log
+                     * to avoid underflow, see Manning et al.,
+                     * "Information Retrieval", Chapter 12, Equation 12.12
+                     * (link: http://nlp.stanford.edu/IR-book/)
+                     */
+                    score += Math.log((1.0 - lambda) * M_c + lambda * M_d);
+
+                }
+                return score;
+            } else {
+                throw new ElasticSearchException("Could not compute language model score, word count field missing.");
+            }
+
+        } catch (IOException ex) {
+            throw new ElasticSearchException("Could not compute language model score: ", ex);
+        }
+    }
+
+}

--- a/src/main/java/org/elasticsearch/examples/nativescript/script/PhraseScoreScript.java
+++ b/src/main/java/org/elasticsearch/examples/nativescript/script/PhraseScoreScript.java
@@ -1,0 +1,88 @@
+package org.elasticsearch.examples.nativescript.script;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.script.AbstractSearchScript;
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.NativeScriptFactory;
+import org.elasticsearch.search.lookup.IndexField;
+import org.elasticsearch.search.lookup.IndexLookup;
+import org.elasticsearch.search.lookup.TermPosition;
+
+/**
+ * Script that scores documents by distance of two given terms in a text, see
+ * Manning et al., "Information Retrieval", Chapter 2.4 (link:
+ * http://nlp.stanford.edu/IR-book/) for more information on positional indexes.
+ * Might be useful if you search for names and know first and last name.
+ */
+public class PhraseScoreScript extends AbstractSearchScript {
+
+    // the field containing the terms that should be scored, must be initialized
+    // in constructor from parameters.
+    String field = null;
+    // terms that are used for scoring
+    ArrayList<String> terms = null;
+
+    final static public String SCRIPT_NAME = "phrase_script_score";
+
+    /**
+     * Factory that is registered in
+     * {@link org.elasticsearch.examples.nativescript.plugin.NativeScriptExamplesPlugin#onModule(org.elasticsearch.script.ScriptModule)}
+     * method when the plugin is loaded.
+     */
+    public static class Factory implements NativeScriptFactory {
+
+        /**
+         * This method is called for every search on every shard.
+         * 
+         * @param params
+         *            list of script parameters passed with the query
+         * @return new native script
+         */
+        @Override
+        public ExecutableScript newScript(@Nullable Map<String, Object> params) {
+            return new PhraseScoreScript(params);
+        }
+    }
+
+    /**
+     * @param params
+     *            terms that a scored are placed in this parameter. Initialize
+     *            them here.
+     */
+    private PhraseScoreScript(Map<String, Object> params) {
+        params.entrySet();
+        // get the terms
+        terms = (ArrayList<String>) params.get("terms");
+        // get the field
+        field = (String) params.get("field");
+        if (field == null || terms == null) {
+            throw new ElasticSearchException("cannot initialize " + SCRIPT_NAME + ": field or terms parameter missing!");
+        }
+        assert (terms.size() == 2);
+    }
+
+    @Override
+    public Object run() {
+        double score = 1.e10;
+        // first, get the ShardTerms object for the field.
+        IndexField indexField = this.indexLookup().get(field);
+        // get the positions iterators
+        Iterator<TermPosition> firstNameIter = indexField.get(terms.get(0), IndexLookup.FLAG_POSITIONS).iterator();
+        Iterator<TermPosition> lastNameIter = indexField.get(terms.get(1), IndexLookup.FLAG_POSITIONS).iterator();
+        int lastNamePos = -1;
+        while (firstNameIter.hasNext()) {
+            int firstNamePos = firstNameIter.next().position;
+            while (lastNameIter.hasNext() && lastNamePos < firstNamePos) {
+                lastNamePos = lastNameIter.next().position;
+            }
+            score = Math.min(score, lastNamePos - firstNamePos);
+        }
+        return 1.0 / (float) score;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/examples/nativescript/script/TFIDFScoreScript.java
+++ b/src/main/java/org/elasticsearch/examples/nativescript/script/TFIDFScoreScript.java
@@ -1,0 +1,90 @@
+package org.elasticsearch.examples.nativescript.script;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.script.AbstractSearchScript;
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.NativeScriptFactory;
+import org.elasticsearch.search.lookup.IndexField;
+import org.elasticsearch.search.lookup.IndexFieldTerm;
+
+/**
+ * Script that scores documents as sum_t(tf_t * (#docs+2)/(df_t+1)), which
+ * equals ntn in SMART notation, see Manning et al., "Information Retrieval",
+ * Chapter 6, Figure 6.15 (link: http://nlp.stanford.edu/IR-book/) This
+ * implementation only scores a list of terms on one field.
+ */
+public class TFIDFScoreScript extends AbstractSearchScript {
+
+    // the field containing the terms that should be scored, must be initialized
+    // in constructor from parameters.
+    String field = null;
+    // terms that are used for scoring
+    ArrayList<String> terms = null;
+
+    final static public String SCRIPT_NAME = "tfidf_script_score";
+
+    /**
+     * Factory that is registered in
+     * {@link org.elasticsearch.examples.nativescript.plugin.NativeScriptExamplesPlugin#onModule(org.elasticsearch.script.ScriptModule)}
+     * method when the plugin is loaded.
+     */
+    public static class Factory implements NativeScriptFactory {
+
+        /**
+         * This method is called for every search on every shard.
+         * 
+         * @param params
+         *            list of script parameters passed with the query
+         * @return new native script
+         */
+        @Override
+        public ExecutableScript newScript(@Nullable Map<String, Object> params) {
+            return new TFIDFScoreScript(params);
+        }
+    }
+
+    /**
+     * @param params
+     *            terms that a scored are placed in this parameter. Initialize
+     *            them here.
+     */
+    private TFIDFScoreScript(Map<String, Object> params) {
+        params.entrySet();
+        // get the terms
+        terms = (ArrayList<String>) params.get("terms");
+        // get the field
+        field = (String) params.get("field");
+        if (field == null || terms == null) {
+            throw new ElasticSearchException("cannot initialize " + SCRIPT_NAME + ": field or terms parameter missing!");
+        }
+    }
+
+    @Override
+    public Object run() {
+        try {
+            float score = 0;
+            // first, get the IndexField object for the field.
+            IndexField indexField = indexLookup().get(field);
+            for (int i = 0; i < terms.size(); i++) {
+                // Now, get the IndexFieldTerm object that can be used to access all
+                // the term statistics
+                IndexFieldTerm indexFieldTerm = indexField.get(terms.get(i));
+                // compute the most naive tfidf and add to current score
+                int df = (int) indexFieldTerm.df();
+                int tf = indexFieldTerm.tf();
+                if (df != 0 && tf != 0) {
+                    score += (float) indexFieldTerm.tf() * Math.log(((float) indexField.docCount() + 2.0) / ((float) df + 1.0));
+                }
+            }
+            return score;
+        } catch (IOException ex) {
+            throw new ElasticSearchException("Could not compute tfidf: ", ex);
+        }
+    }
+
+}

--- a/src/test/java/org/elasticsearch/examples/nativescript/script/TermScoringScriptTests.java
+++ b/src/test/java/org/elasticsearch/examples/nativescript/script/TermScoringScriptTests.java
@@ -1,0 +1,173 @@
+package org.elasticsearch.examples.nativescript.script;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.lucene.search.function.CombineFunction;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.junit.Test;
+
+/**
+ * Test if the computed tfidf in NaiveTFIDFScoreScript equals 0.0 for each
+ * document as would be expected if each document in the index contains only one
+ * and always the same term.
+ * 
+ */
+public class TermScoringScriptTests extends AbstractSearchScriptTests {
+
+    final static String[] searchTerms = { "foo", "bar" };
+    final static String field = "field";
+    final static String wordCountField = field + ".word_count";
+    final static  String placeholder = "placeholder";
+    final static Double[] weights = { 1.0, 1.0 };
+    final static int numDocs = 100;
+
+    @Test
+    public void testTFIDF() throws Exception {
+
+        initData();
+
+        // initialize parameters for script
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("field", field);
+        params.put("terms", searchTerms);
+
+        // Retrieve records and see if they scored 0.0
+        SearchResponse searchResponse = client()
+                .prepareSearch("test")
+                .setQuery(
+                        QueryBuilders.functionScoreQuery()
+                                .add(ScoreFunctionBuilders.scriptFunction(TFIDFScoreScript.SCRIPT_NAME, "native", params))
+                                .boostMode(CombineFunction.REPLACE.getName())).setSize(numDocs).execute().actionGet();
+        assertNoFailures(searchResponse);
+        assertHitCount(searchResponse, numDocs);
+        SearchHit[] hits = searchResponse.getHits().hits();
+        for (int i = 0; i < numDocs; i++) {
+            assertThat(hits[i].getId(), equalTo(Integer.toString(numDocs - i - 1)));
+        }
+
+    }
+
+    @Test
+    public void testCosineSimilarity() throws Exception {
+
+        initData();
+
+        // initialize parameters for script
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("field", field);
+        params.put("terms", searchTerms);
+        params.put("weights", weights);
+
+        // Retrieve records and see if they scored 0.0
+        SearchResponse searchResponse = client()
+                .prepareSearch("test")
+                .setQuery(
+                        QueryBuilders.functionScoreQuery()
+                                .add(ScoreFunctionBuilders.scriptFunction(CosineSimilarityScoreScript.SCRIPT_NAME, "native", params))
+                                .boostMode(CombineFunction.REPLACE.getName())).setSize(numDocs).execute().actionGet();
+        assertNoFailures(searchResponse);
+        assertHitCount(searchResponse, numDocs);
+        SearchHit[] hits = searchResponse.getHits().hits();
+        for (int i = 0; i < numDocs; i++) {
+            assertThat(hits[i].getId(), equalTo(Integer.toString(i)));
+        }
+    }
+
+    @Test
+    public void testPhraseScorer() throws Exception {
+
+        initData();
+
+        // initialize parameters for script
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("field", field);
+        params.put("terms", searchTerms);
+
+        // Retrieve records and see if they scored 0.0
+        SearchResponse searchResponse = client()
+                .prepareSearch("test")
+                .setQuery(
+                        QueryBuilders.functionScoreQuery()
+                                .add(ScoreFunctionBuilders.scriptFunction(PhraseScoreScript.SCRIPT_NAME, "native", params))
+                                .boostMode(CombineFunction.REPLACE.getName())).setSize(numDocs).execute().actionGet();
+        assertNoFailures(searchResponse);
+        assertHitCount(searchResponse, numDocs);
+        SearchHit[] hits = searchResponse.getHits().hits();
+        for (int i = 0; i < numDocs; i++) {
+            assertThat(hits[i].getId(), equalTo(Integer.toString(i)));
+            assertThat((double) hits[i].score(), closeTo(1.0 / (float) (i + 2), 1.e-6));
+        }
+    }
+
+    @Test
+    public void testLanguageModelScorer() throws Exception {
+
+        initData();
+
+        // initialize parameters for script
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("field", field);
+        params.put("terms", searchTerms);
+        params.put("word_count_field", wordCountField);
+        params.put("lambda", 0.9);
+
+        // Retrieve records and see if they scored 0.0
+        SearchResponse searchResponse = client()
+                .prepareSearch("test")
+                .setQuery(
+                        QueryBuilders.functionScoreQuery()
+                                .add(ScoreFunctionBuilders.scriptFunction(LanguageModelScoreScript.SCRIPT_NAME, "native", params))
+                                .boostMode(CombineFunction.REPLACE.getName())).setSize(numDocs).execute().actionGet();
+        assertNoFailures(searchResponse);
+        assertHitCount(searchResponse, numDocs);
+        SearchHit[] hits = searchResponse.getHits().hits();
+        for (int i = 0; i < numDocs; i++) {
+            assertThat(hits[i].getId(), equalTo(Integer.toString(i)));
+        }
+    }
+
+    private void initData() throws IOException, InterruptedException, ExecutionException {
+        // Create a new index
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type").startObject("properties").startObject(field)
+                .field("type", "multi_field").startObject("fields").startObject(field).field("type", "String").endObject()
+                .startObject("word_count").field("analyzer", "standard").field("type", "token_count").startObject("fielddata")
+                .field("format", "doc_values").endObject().endObject().endObject().endObject().endObject().endObject().endObject().string();
+        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type", mapping));
+
+        List<IndexRequestBuilder> indexBuilders = new ArrayList<IndexRequestBuilder>();
+        // Index numDocs records (0..99)
+        for (int i = 0; i < numDocs; i++) {
+            indexBuilders.add(client().prepareIndex("test", "type", Integer.toString(i))
+                    .setSource(XContentFactory.jsonBuilder().startObject().field(field, createText(i + 1)).endObject())
+                    .setId(Integer.toString(i)));
+        }
+        indexRandom(true, indexBuilders);
+    }
+
+    private String createText(int numFoo) {
+        String text = "";
+        for (int i = 0; i < numFoo; i++) {
+            text = text + " foo ";
+        }
+        for (int i = 0; i < numFoo; i++) {
+            text = text + " " + placeholder + " ";
+        }
+        return text + " bar";
+    }
+}


### PR DESCRIPTION
Examples for term based script scoring in a native script.
See also
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-advanced-scripting.html

This adds scripts for
- cosime similarity
- tfidf
- language model scoring
- simple phrase scorer
