### PR TITLE
Use BigInteger.valueOf, not constructor

### DIFF
--- a/src/main/java/org/elasticsearch/examples/nativescript/script/IsPrimeSearchScript.java
+++ b/src/main/java/org/elasticsearch/examples/nativescript/script/IsPrimeSearchScript.java
@@ -85,7 +85,7 @@ public class IsPrimeSearchScript extends AbstractSearchScript {
         if (docValue != null && !docValue.isEmpty()) {
             try {
                 // Try to parse it as an integer
-                BigInteger bigInteger = new BigInteger(Long.toString(((Longs) docValue).getValue()));
+                BigInteger bigInteger = BigInteger.valueOf(((Longs) docValue).getValue());
                 // Check if it's prime
                 return bigInteger.isProbablePrime(certainty);
             } catch (NumberFormatException ex) {


### PR DESCRIPTION
Prefer the use of [`BigInteger.valueOf`](http://docs.oracle.com/javase/7/docs/api/java/math/BigInteger.html#valueOf%28long%29) over the constructor to allow the JVM to possibly reuse cached values (and otherwise just simplifies it in my opinion).